### PR TITLE
Phwo erf ints

### DIFF
--- a/src/lible/ints/ints.hpp
+++ b/src/lible/ints/ints.hpp
@@ -140,6 +140,29 @@ namespace lible
                                         const BoysGrid &boys_grid, const ShellPairData &sp_data);
 
         /**
+         * Calculates a batch of normalized Coulombic operator integrals for the shell pair 'ipair'. 
+         * For every charge a batch of integrals is calculated.
+         * The charges should be given as a list  {(x, y, z, charge)}, with xyz-coordinates in
+         * atomic units. The Boys grid should be initialized for lab = la + lb in the given shell
+         * pair data.
+         */
+        std::vector<vec2d>
+        potentialAtExternalChargesKernel(const int ipair, const std::vector<std::array<double, 4>> &charges,
+                                        const BoysGrid &boys_grid, const ShellPairData &sp_data);
+
+        /**
+         * Calculates a batch of normalizederf-attenuated  Coulombic operator integrals for the shell pair 'ipair'. 
+         * For every charge a batch of integrals is calculated.
+         * The charges should be given as a list  {(x, y, z, charge)}, with xyz-coordinates in
+         * atomic units. The Boys grid should be initialized for lab = la + lb in the given shell
+         * pair data. The screening factor omega should be given as a std::vector<double>
+         */
+        std::vector<vec2d>
+        potentialAtExternalChargesErfKernel(const int ipair, const std::vector<std::array<double, 4>> &charges,
+																				const std::vector<double> &omegas,
+                                        const BoysGrid &boys_grid, const ShellPairData &sp_data);
+
+        /**
          * \ingroup ints
          * Calculates the dipole moment integral matrices for the \f$x,y,z\f$-directions.
          */

--- a/src/lible/ints/ints.hpp
+++ b/src/lible/ints/ints.hpp
@@ -142,7 +142,7 @@ namespace lible
                                         const BoysGrid &boys_grid, const ShellPairData &sp_data);
 
         /**
-         * Calculates a batch of normalized Coulombic operator integrals for the shell pair 'ipair'. 
+         * Calculates a batch of normalized Coulombic operator integrals for the shell pair 'ipair'.
          * For every charge a batch of integrals is calculated.
          * The charges should be given as a list  {(x, y, z, charge)}, with xyz-coordinates in
          * atomic units. The Boys grid should be initialized for lab = la + lb in the given shell
@@ -150,10 +150,10 @@ namespace lible
          */
         std::vector<vec2d>
         potentialAtExternalChargesKernel(const int ipair, const std::vector<std::array<double, 4>> &charges,
-                                        const BoysGrid &boys_grid, const ShellPairData &sp_data);
+                                         const BoysGrid &boys_grid, const ShellPairData &sp_data);
 
         /**
-         * Calculates a batch of normalizederf-attenuated  Coulombic operator integrals for the shell pair 'ipair'. 
+         * Calculates a batch of normalizederf-attenuated  Coulombic operator integrals for the shell pair 'ipair'.
          * For every charge a batch of integrals is calculated.
          * The charges should be given as a list  {(x, y, z, charge)}, with xyz-coordinates in
          * atomic units. The Boys grid should be initialized for lab = la + lb in the given shell
@@ -161,8 +161,8 @@ namespace lible
          */
         std::vector<vec2d>
         potentialAtExternalChargesErfKernel(const int ipair, const std::vector<std::array<double, 4>> &charges,
-																				const std::vector<double> &omegas,
-                                        const BoysGrid &boys_grid, const ShellPairData &sp_data);
+                                            const std::vector<double> &omegas,
+                                            const BoysGrid &boys_grid, const ShellPairData &sp_data);
 
         /**
          * \ingroup ints

--- a/src/lible/ints/oneel/nuclear_attraction.cpp
+++ b/src/lible/ints/oneel/nuclear_attraction.cpp
@@ -469,11 +469,10 @@ LI::externalChargesOperatorD1Kernel(const int ipair, const vector<array<double, 
     return ints_sph;
 }
 
-
 std::vector<lible::vec2d>
-LI::potentialAtExternalChargesKernel(const int ipair, 
+LI::potentialAtExternalChargesKernel(const int ipair,
                                      const std::vector<std::array<double, 4>> &charges,
-                                     const BoysGrid &boys_grid, 
+                                     const BoysGrid &boys_grid,
                                      const ShellPairData &sp_data)
 {
     const int la = sp_data.la;
@@ -539,15 +538,15 @@ LI::potentialAtExternalChargesKernel(const int ipair,
                     for (int u = 0; u <= lab; u++)
                         for (int v = 0; v <= lab; v++)
                             rints_sum[icharge](t, u, v) += charge * rints(t, u, v);
-            
+
                 for (const auto &[i, j, k, mu] : cart_exps_a)
                     for (const auto &[i_, j_, k_, nu] : cart_exps_b)
                         for (int t = 0; t <= i + i_; t++)
                             for (int u = 0; u <= j + j_; u++)
                                 for (int v = 0; v <= k + k_; v++)
                                     ints_cart[icharge](mu, nu) += (-1) * fac * // -1 = charge of electron
-                                                        Ex(i, i_, t) * Ey(j, j_, u) * Ez(k, k_, v) *
-                                                        rints_sum[icharge](t, u, v);
+                                                                  Ex(i, i_, t) * Ey(j, j_, u) * Ez(k, k_, v) *
+                                                                  rints_sum[icharge](t, u, v);
             }
         }
 
@@ -557,7 +556,7 @@ LI::potentialAtExternalChargesKernel(const int ipair,
 
     int ofs_norm_a = sp_data.offsets_norms[2 * ipair + 0];
     int ofs_norm_b = sp_data.offsets_norms[2 * ipair + 1];
-    
+
     for (size_t icharge = 0; icharge < charges.size(); icharge++)
     {
         ints_sph[icharge] = trafo2Spherical(la, lb, ints_cart[icharge]);

--- a/src/lible/ints/oneel/nuclear_attraction.cpp
+++ b/src/lible/ints/oneel/nuclear_attraction.cpp
@@ -44,6 +44,15 @@ namespace lible::ints
     vector<array<vec2d, 3>>
     externalChargesOperatorD1Kernel(const int ipair, const vector<array<double, 4>> &charges,
                                     const BoysGrid &boys_grid, const ShellPairData &sp_data);
+
+    std::vector<vec2d>
+    potentialAtExternalChargesKernel(const int ipair, const std::vector<std::array<double, 4>> &charges,
+                                        const BoysGrid &boys_grid, const ShellPairData &sp_data);
+
+    std::vector<vec2d>
+    potentialAtExternalChargesErfKernel(const int ipair, const std::vector<std::array<double, 4>> &charges,
+																				const vector<double> &omegas,
+                                        const BoysGrid &boys_grid, const ShellPairData &sp_data);
 }
 
 lible::vec2d LI::externalChargesKernel(const int ipair, const vector<array<double, 4>> &charges,
@@ -451,6 +460,228 @@ LI::externalChargesOperatorD1Kernel(const int ipair, const vector<array<double, 
                 ints_sph[icharge][1](mu, nu) *= norm_a * norm_b;
                 ints_sph[icharge][2](mu, nu) *= norm_a * norm_b;
             }
+
+    return ints_sph;
+}
+
+
+std::vector<lible::vec2d>
+LI::potentialAtExternalChargesKernel(const int ipair, 
+                                     const std::vector<std::array<double, 4>> &charges,
+                                     const BoysGrid &boys_grid, 
+                                     const ShellPairData &sp_data)
+{
+    const int la = sp_data.la;
+    const int lb = sp_data.lb;
+    const int lab = la + lb;
+    const int cdepth_a = sp_data.cdepths[2 * ipair + 0];
+    const int cdepth_b = sp_data.cdepths[2 * ipair + 1];
+    const int cofs_a = sp_data.coffsets[2 * ipair + 0];
+    const int cofs_b = sp_data.coffsets[2 * ipair + 1];
+
+    const double *cexps_a = &sp_data.exps[cofs_a];
+    const double *cexps_b = &sp_data.exps[cofs_b];
+    const double *ccoeffs_a = &sp_data.coeffs[cofs_a];
+    const double *ccoeffs_b = &sp_data.coeffs[cofs_b];
+    const double *xyz_a = &sp_data.coords[6 * ipair + 0];
+    const double *xyz_b = &sp_data.coords[6 * ipair + 3];
+
+    const auto &cart_exps_a = cart_exps[la];
+    const auto &cart_exps_b = cart_exps[lb];
+
+    int n_cart_a = numCartesians(la);
+    int n_cart_b = numCartesians(lb);
+
+    int n_ext_points = charges.size();
+
+    vector<vec2d> ints_cart(n_ext_points, vec2d(Fill(0), n_cart_a, n_cart_b));
+
+    for (int ia = 0, iab = 0; ia < cdepth_a; ia++)
+        for (int ib = 0; ib < cdepth_b; ib++, iab++)
+        {
+            double a = cexps_a[ia];
+            double b = cexps_b[ib];
+            double da = ccoeffs_a[ia];
+            double db = ccoeffs_b[ib];
+
+            double p = a + b;
+            double dadb = da * db;
+            double fac = 2 * (M_PI / p) * dadb;
+
+            auto [Ex, Ey, Ez] = ecoeffsPrimitivePair(a, b, la, lb, xyz_a, xyz_b);
+
+            array<double, 3> xyz_p{(a * xyz_a[0] + b * xyz_b[0]) / p,
+                                   (a * xyz_a[1] + b * xyz_b[1]) / p,
+                                   (a * xyz_a[2] + b * xyz_b[2]) / p};
+
+            vector<vec3d> rints_sum(n_ext_points, vec3d(Fill(0), lab + 1));
+
+            for (size_t icharge = 0; icharge < charges.size(); icharge++)
+            {
+                auto [xc, yc, zc, charge] = charges[icharge];
+
+                array<double, 3> xyz_pc{xyz_p[0] - xc, xyz_p[1] - yc, xyz_p[2] - zc};
+
+                double xx{xyz_pc[0]}, xy{xyz_pc[1]}, xz{xyz_pc[2]};
+                double xyz_pc_dot = xx * xx + xy * xy + xz * xz;
+                double x = p * xyz_pc_dot;
+
+                vector<double> fnx = calcBoysF(lab, x, boys_grid);
+
+                vec3d rints = calcRInts3D(lab, p, &xyz_pc[0], &fnx[0]);
+
+                for (int t = 0; t <= lab; t++)
+                    for (int u = 0; u <= lab; u++)
+                        for (int v = 0; v <= lab; v++)
+                            rints_sum[icharge](t, u, v) += charge * rints(t, u, v);
+            
+                for (const auto &[i, j, k, mu] : cart_exps_a)
+                    for (const auto &[i_, j_, k_, nu] : cart_exps_b)
+                        for (int t = 0; t <= i + i_; t++)
+                            for (int u = 0; u <= j + j_; u++)
+                                for (int v = 0; v <= k + k_; v++)
+                                    ints_cart[icharge](mu, nu) += (-1) * fac * // -1 = charge of electron
+                                                        Ex(i, i_, t) * Ey(j, j_, u) * Ez(k, k_, v) *
+                                                        rints_sum[icharge](t, u, v);
+            }
+        }
+
+    int n_sph_a = numSphericals(la);
+    int n_sph_b = numSphericals(lb);
+    vector<vec2d> ints_sph(n_ext_points, vec2d(Fill(0), n_sph_a, n_sph_b));
+
+    int ofs_norm_a = sp_data.offsets_norms[2 * ipair + 0];
+    int ofs_norm_b = sp_data.offsets_norms[2 * ipair + 1];
+    
+    for (size_t icharge = 0; icharge < charges.size(); icharge++)
+    {
+        ints_sph[icharge] = trafo2Spherical(la, lb, ints_cart[icharge]);
+
+        for (size_t mu = 0; mu < ints_sph[icharge].dim<0>(); mu++)
+        {
+            for (size_t nu = 0; nu < ints_sph[icharge].dim<1>(); nu++)
+            {
+                double norm_a = sp_data.norms[ofs_norm_a + mu];
+                double norm_b = sp_data.norms[ofs_norm_b + nu];
+                ints_sph[icharge](mu, nu) *= norm_a * norm_b;
+            }
+        }
+    }
+
+    return ints_sph;
+}
+std::vector<lible::vec2d>
+LI::potentialAtExternalChargesErfKernel(const int ipair, 
+                                        const std::vector<std::array<double, 4>> &charges,
+																				const vector<double> &omegas,
+                                        const BoysGrid &boys_grid, 
+                                        const ShellPairData &sp_data)
+{
+    int la = sp_data.la;
+    int lb = sp_data.lb;
+    int lab = la + lb;
+    int cdepth_a = sp_data.cdepths[2 * ipair + 0];
+    int cdepth_b = sp_data.cdepths[2 * ipair + 1];
+    int cofs_a = sp_data.coffsets[2 * ipair + 0];
+    int cofs_b = sp_data.coffsets[2 * ipair + 1];
+
+    const double *cexps_a = &sp_data.exps[cofs_a];
+    const double *cexps_b = &sp_data.exps[cofs_b];
+    const double *ccoeffs_a = &sp_data.coeffs[cofs_a];
+    const double *ccoeffs_b = &sp_data.coeffs[cofs_b];
+    const double *xyz_a = &sp_data.coords[6 * ipair + 0];
+    const double *xyz_b = &sp_data.coords[6 * ipair + 3];
+
+    const auto &cart_exps_a = cart_exps[la];
+    const auto &cart_exps_b = cart_exps[lb];
+
+    int n_cart_a = numCartesians(la);
+    int n_cart_b = numCartesians(lb);
+
+		int n_ext_points = charges.size();
+		
+    vector<vec2d> 
+			ints_cart(n_ext_points, vec2d(Fill(0), n_cart_a, n_cart_b));
+
+    for (int ia = 0, iab = 0; ia < cdepth_a; ia++)
+        for (int ib = 0; ib < cdepth_b; ib++, iab++)
+        {
+            double a = cexps_a[ia];
+            double b = cexps_b[ib];
+            double da = ccoeffs_a[ia];
+            double db = ccoeffs_b[ib];
+
+            double p = a + b;
+            double dadb = da * db;
+            double fac = 2 * (M_PI / p) * dadb;
+
+            auto [Ex, Ey, Ez] = ecoeffsPrimitivePair(a, b, la, lb, xyz_a, xyz_b);
+
+            array<double, 3> xyz_p{(a * xyz_a[0] + b * xyz_b[0]) / p,
+                                   (a * xyz_a[1] + b * xyz_b[1]) / p,
+                                   (a * xyz_a[2] + b * xyz_b[2]) / p};
+
+            vector<vec3d> 
+							rints_sum(n_ext_points, vec3d(Fill(0), lab + 1));
+
+            for (size_t icharge = 0; icharge < charges.size(); icharge++)
+            {
+                auto [xc, yc, zc, charge] = charges[icharge];
+
+                array<double, 3> xyz_pc{xyz_p[0] - xc, xyz_p[1] - yc, xyz_p[2] - zc};
+
+                double xx{xyz_pc[0]}, xy{xyz_pc[1]}, xz{xyz_pc[2]};
+                double xyz_pc_dot = xx * xx + xy * xy + xz * xz;
+
+                double omega_factor = omegas[icharge] / std::pow(omegas[icharge] * omegas[icharge] + p, 0.5);
+
+                double omega_squared = omegas[icharge] * omegas[icharge];
+
+                // second part of (52) in https://doi.org/10.1039/B605188J
+                double x = p * xyz_pc_dot * omega_squared / (omega_squared + p);
+
+                vector<double> fnx = calcBoysF(lab, x, boys_grid);
+
+                vec3d rints = calcRInts3DErf(lab, p, omegas[icharge], &xyz_pc[0], &fnx[0]);
+
+                for (int t = 0; t <= lab; t++)
+                    for (int u = 0; u <= lab; u++)
+                        for (int v = 0; v <= lab; v++)
+                            rints_sum[icharge](t, u, v) 
+															+= charge * omega_factor // erf-related factors
+                                                  * rints(t, u, v);
+                for (const auto &[i, j, k, mu] : cart_exps_a)
+                    for (const auto &[i_, j_, k_, nu] : cart_exps_b)
+                        for (int t = 0; t <= i + i_; t++)
+                            for (int u = 0; u <= j + j_; u++)
+                                for (int v = 0; v <= k + k_; v++)
+                                    ints_cart[icharge](mu, nu) += (-1) * fac * // -1 = charge of electron
+                                                         Ex(i, i_, t) * Ey(j, j_, u) * Ez(k, k_, v) *
+                                                         rints_sum[icharge](t, u, v);
+						}
+        }
+
+		int n_sph_a = numSphericals(la);
+    int n_sph_b = numSphericals(lb);
+    vector<vec2d> ints_sph(n_ext_points, vec2d(Fill(0), n_sph_a, n_sph_b));
+
+    int ofs_norm_a = sp_data.offsets_norms[2 * ipair + 0];
+    int ofs_norm_b = sp_data.offsets_norms[2 * ipair + 1];
+    
+    for (size_t icharge = 0; icharge < charges.size(); icharge++)
+    {
+        ints_sph[icharge] = trafo2Spherical(la, lb, ints_cart[icharge]);
+
+        for (size_t mu = 0; mu < ints_sph[icharge].dim<0>(); mu++)
+        {
+            for (size_t nu = 0; nu < ints_sph[icharge].dim<1>(); nu++)
+            {
+                double norm_a = sp_data.norms[ofs_norm_a + mu];
+                double norm_b = sp_data.norms[ofs_norm_b + nu];
+                ints_sph[icharge](mu, nu) *= norm_a * norm_b;
+            }
+        }
+    }
 
     return ints_sph;
 }

--- a/src/lible/ints/oneel/nuclear_attraction.cpp
+++ b/src/lible/ints/oneel/nuclear_attraction.cpp
@@ -558,23 +558,22 @@ LI::potentialAtExternalChargesKernel(const int ipair,
         ints_sph[icharge] = trafo2Spherical(la, lb, ints_cart[icharge]);
 
         for (size_t mu = 0; mu < ints_sph[icharge].dim<0>(); mu++)
-        {
             for (size_t nu = 0; nu < ints_sph[icharge].dim<1>(); nu++)
             {
                 double norm_a = sp_data.norms[ofs_norm_a + mu];
                 double norm_b = sp_data.norms[ofs_norm_b + nu];
                 ints_sph[icharge](mu, nu) *= norm_a * norm_b;
             }
-        }
     }
 
     return ints_sph;
 }
+
 std::vector<lible::vec2d>
-LI::potentialAtExternalChargesErfKernel(const int ipair, 
+LI::potentialAtExternalChargesErfKernel(const int ipair,
                                         const std::vector<std::array<double, 4>> &charges,
-																				const vector<double> &omegas,
-                                        const BoysGrid &boys_grid, 
+                                        const vector<double> &omegas,
+                                        const BoysGrid &boys_grid,
                                         const ShellPairData &sp_data)
 {
     int la = sp_data.la;
@@ -598,10 +597,10 @@ LI::potentialAtExternalChargesErfKernel(const int ipair,
     int n_cart_a = numCartesians(la);
     int n_cart_b = numCartesians(lb);
 
-		int n_ext_points = charges.size();
-		
-    vector<vec2d> 
-			ints_cart(n_ext_points, vec2d(Fill(0), n_cart_a, n_cart_b));
+    int n_ext_points = charges.size();
+
+    vector<vec2d>
+        ints_cart(n_ext_points, vec2d(Fill(0), n_cart_a, n_cart_b));
 
     for (int ia = 0, iab = 0; ia < cdepth_a; ia++)
         for (int ib = 0; ib < cdepth_b; ib++, iab++)
@@ -621,8 +620,8 @@ LI::potentialAtExternalChargesErfKernel(const int ipair,
                                    (a * xyz_a[1] + b * xyz_b[1]) / p,
                                    (a * xyz_a[2] + b * xyz_b[2]) / p};
 
-            vector<vec3d> 
-							rints_sum(n_ext_points, vec3d(Fill(0), lab + 1));
+            vector<vec3d>
+                rints_sum(n_ext_points, vec3d(Fill(0), lab + 1));
 
             for (size_t icharge = 0; icharge < charges.size(); icharge++)
             {
@@ -647,40 +646,37 @@ LI::potentialAtExternalChargesErfKernel(const int ipair,
                 for (int t = 0; t <= lab; t++)
                     for (int u = 0; u <= lab; u++)
                         for (int v = 0; v <= lab; v++)
-                            rints_sum[icharge](t, u, v) 
-															+= charge * omega_factor // erf-related factors
-                                                  * rints(t, u, v);
+                            rints_sum[icharge](t, u, v) += charge * omega_factor // erf-related factor
+                                                           * rints(t, u, v);
                 for (const auto &[i, j, k, mu] : cart_exps_a)
                     for (const auto &[i_, j_, k_, nu] : cart_exps_b)
                         for (int t = 0; t <= i + i_; t++)
                             for (int u = 0; u <= j + j_; u++)
                                 for (int v = 0; v <= k + k_; v++)
                                     ints_cart[icharge](mu, nu) += (-1) * fac * // -1 = charge of electron
-                                                         Ex(i, i_, t) * Ey(j, j_, u) * Ez(k, k_, v) *
-                                                         rints_sum[icharge](t, u, v);
-						}
+                                                                  Ex(i, i_, t) * Ey(j, j_, u) * Ez(k, k_, v) *
+                                                                  rints_sum[icharge](t, u, v);
+            }
         }
 
-		int n_sph_a = numSphericals(la);
+    int n_sph_a = numSphericals(la);
     int n_sph_b = numSphericals(lb);
     vector<vec2d> ints_sph(n_ext_points, vec2d(Fill(0), n_sph_a, n_sph_b));
 
     int ofs_norm_a = sp_data.offsets_norms[2 * ipair + 0];
     int ofs_norm_b = sp_data.offsets_norms[2 * ipair + 1];
-    
+
     for (size_t icharge = 0; icharge < charges.size(); icharge++)
     {
         ints_sph[icharge] = trafo2Spherical(la, lb, ints_cart[icharge]);
 
         for (size_t mu = 0; mu < ints_sph[icharge].dim<0>(); mu++)
-        {
             for (size_t nu = 0; nu < ints_sph[icharge].dim<1>(); nu++)
             {
                 double norm_a = sp_data.norms[ofs_norm_a + mu];
                 double norm_b = sp_data.norms[ofs_norm_b + nu];
                 ints_sph[icharge](mu, nu) *= norm_a * norm_b;
             }
-        }
     }
 
     return ints_sph;


### PR DESCRIPTION
Added:
- calcPotentialAtExternalChargesKernel
- calcPotentialAtExternalChargesErfKernel
both return an std::vector<vec2d>

They follow the conventions of "externalCharges" and NOT the template approach of "nuclear_attraction"  