### PR TITLE
merge phwo_erf_ints into main

### DIFF
--- a/src/lible/ints/ints.hpp
+++ b/src/lible/ints/ints.hpp
@@ -173,6 +173,18 @@ namespace lible::ints
                             const BoysGrid &boys_grid, const ShellPairData &sp_data);
 
     // /**
+    //      * Calculates a batch of normalized Coulombic interaction energy integral derivatives for
+    //      * the shell pair 'ipair'. The derivatives are given as (Ax, Ay, Az, Bx, By, Bz).
+    //      * In spherical basis. The charges should be given as a list  {(x, y, z, charge)}, with
+    //      * xyz-coordinates in atomic units. The Boys grid should be initialized for lab = la + lb
+    //      * in the given shell pair data.
+    //      */
+    std::array<vec2d, 6>
+    externalChargesErfD1Kernel(int ipair, const std::vector<std::array<double, 4>> &charges,
+		    	       const std::vector<double> &omegas, const BoysGrid &boys_grid, 
+			       const ShellPairData &sp_data);
+
+    // /**
     //      * Calculates a batch of normalized Coulombic operator derivative integrals for the shell
     //      * pair 'ipair'. The derivatives are given for each charge as (Ax, Ay, Az). In spherical basis.
     //      * The charges should be given as a list  {(x, y, z, charge)}, with xyz-coordinates in
@@ -182,6 +194,18 @@ namespace lible::ints
     std::vector<std::array<vec2d, 3>>
     externalChargesOperatorD1Kernel(int ipair, const std::vector<std::array<double, 4>> &charges,
                                     const BoysGrid &boys_grid, const ShellPairData &sp_data);
+
+    // /**
+    //      * Calculates a batch of normalized Coulombic operator derivative integrals for the shell
+    //      * pair 'ipair'. The derivatives are given for each charge as (Ax, Ay, Az). In spherical basis.
+    //      * The charges should be given as a list  {(x, y, z, charge)}, with xyz-coordinates in
+    //      * atomic units. The Boys grid should be initialized for lab = la + lb in the given shell
+    //      * pair data.
+    //      */
+    std::vector<std::array<vec2d, 3>>
+    externalChargesOperatorErfD1Kernel(int ipair, const std::vector<std::array<double, 4>> &charges,
+                                       const std::vector<double> &omegas, const BoysGrid &boys_grid, 
+				       const ShellPairData &sp_data);
 
     // /**
     //      * Calculates a batch of normalized Coulombic operator integrals for the shell pair 'ipair'.

--- a/src/lible/ints/ints.hpp
+++ b/src/lible/ints/ints.hpp
@@ -195,7 +195,7 @@ namespace lible::ints
     std::array<vec2d, 6>
     externalChargesErfD1Kernel(int ipair, const std::vector<std::array<double, 4>> &charges,
 		    	       const std::vector<double> &omegas, const BoysGrid &boys_grid, 
-			       const ShellPairData &sp_data);
+			           const ShellPairData &sp_data);
 
     // /**
     //      * Calculates a batch of normalized Coulombic operator derivative integrals for the shell

--- a/src/lible/ints/oneelints.cpp
+++ b/src/lible/ints/oneelints.cpp
@@ -59,9 +59,20 @@ namespace lible::ints
                                             const BoysGrid &boys_grid,
                                             const ShellPairData &sp_data);
 
+    array<vec2d, 6> externalChargesErfD1Kernel(const int ipair,
+                                            const vector<array<double, 4>> &charges,
+                                            const vector<double> &omegas,
+                                            const BoysGrid &boys_grid,
+                                            const ShellPairData &sp_data);
+
     vector<array<vec2d, 3>>
     externalChargesOperatorD1Kernel(const int ipair, const vector<array<double, 4>> &charges,
                                     const BoysGrid &boys_grid, const ShellPairData &sp_data);
+
+    vector<array<vec2d, 3>>
+    externalChargesOperatorErfD1Kernel(const int ipair, const vector<array<double, 4>> &charges,
+                                       const std::vector<double> &omegas, const BoysGrid &boys_grid, 
+				       const ShellPairData &sp_data);
 
     std::vector<vec2d>
     potentialAtExternalChargesKernel(const int ipair, const vector<array<double, 4>> &charges,
@@ -810,6 +821,126 @@ lible::vec2d LI::externalChargesErfKernel(const int ipair,
 }
 
 array<lible::vec2d, 6>
+LI::externalChargesErfD1Kernel(const int ipair, const vector<array<double, 4>> &charges,
+		               const vector<double> &omegas, const BoysGrid &boys_grid, 
+			       const ShellPairData &sp_data)
+{
+    int la = sp_data.la;
+    int lb = sp_data.lb;
+    int lab = la + lb;
+    int cdepth_a = sp_data.cdepths[2 * ipair + 0];
+    int cdepth_b = sp_data.cdepths[2 * ipair + 1];
+    int cofs_a = sp_data.coffsets[2 * ipair + 0];
+    int cofs_b = sp_data.coffsets[2 * ipair + 1];
+
+    const double *cexps_a = &sp_data.exps[cofs_a];
+    const double *cexps_b = &sp_data.exps[cofs_b];
+    const double *ccoeffs_a = &sp_data.coeffs[cofs_a];
+    const double *ccoeffs_b = &sp_data.coeffs[cofs_b];
+    const double *xyz_a = &sp_data.coords[6 * ipair + 0];
+    const double *xyz_b = &sp_data.coords[6 * ipair + 3];
+
+    const auto &cart_exps_a = cart_exps[la];
+    const auto &cart_exps_b = cart_exps[lb];
+
+    int n_cart_a = numCartesians(la);
+    int n_cart_b = numCartesians(lb);
+
+    array<vec2d, 6> ints_cart;
+    for (int ideriv = 0; ideriv < 6; ideriv++)
+        ints_cart[ideriv] = vec2d(Fill(0), n_cart_a, n_cart_b);
+
+    for (int ia = 0, iab = 0; ia < cdepth_a; ia++)
+        for (int ib = 0; ib < cdepth_b; ib++, iab++)
+        {
+            double a = cexps_a[ia];
+            double b = cexps_b[ib];
+            double da = ccoeffs_a[ia];
+            double db = ccoeffs_b[ib];
+
+            double p = a + b;
+            double dadb = da * db;
+            double fac = 2 * (M_PI / p) * dadb;
+
+            auto [Ex, Ey, Ez] = ecoeffsPrimitivePair(a, b, la, lb, xyz_a, xyz_b);
+
+            auto [E1x, E1y, E1z] = ecoeffsPrimitivePair_n1(a, b, la, lb, xyz_a, xyz_b,
+                                                           {Ex, Ey, Ez});
+
+            array<double, 3> xyz_p{(a * xyz_a[0] + b * xyz_b[0]) / p,
+                                   (a * xyz_a[1] + b * xyz_b[1]) / p,
+                                   (a * xyz_a[2] + b * xyz_b[2]) / p};
+
+            vec3d rints_sum(Fill(0), lab + 2);
+            for (size_t icharge = 0; icharge < charges.size(); icharge++)
+            {
+                auto [xc, yc, zc, charge] = charges[icharge];
+
+                array<double, 3> xyz_pc{xyz_p[0] - xc, xyz_p[1] - yc, xyz_p[2] - zc};
+
+                double xx{xyz_pc[0]}, xy{xyz_pc[1]}, xz{xyz_pc[2]};
+                double xyz_pc_dot = xx * xx + xy * xy + xz * xz;
+                double x = p * xyz_pc_dot;
+
+		double omega = omegas[icharge];
+		double erf_argument = omega * omega / (omega * omega + p);
+		double erf_factor = std::sqrt(erf_argument);
+
+                vector<double> fnx = calcBoysF(lab + 1, erf_argument * x, boys_grid);
+
+                vec3d rints = calcRInts3DErf(lab + 1, p, omega , &xyz_pc[0], &fnx[0]);
+
+                for (int t = 0; t <= lab + 1; t++)
+                    for (int u = 0; u <= lab + 1; u++)
+                        for (int v = 0; v <= lab + 1; v++)
+                            rints_sum(t, u, v) += erf_factor * charge * rints(t, u, v);
+            }
+
+            for (const auto &[i, j, k, mu] : cart_exps_a)
+                for (const auto &[i_, j_, k_, nu] : cart_exps_b)
+                    for (int t = 0; t <= i + i_; t++)
+                        for (int u = 0; u <= j + j_; u++)
+                            for (int v = 0; v <= k + k_; v++)
+                            {
+                                double dpx = fac * Ex(i, i_, t) * Ey(j, j_, u) * Ez(k, k_, v) * rints_sum(t + 1, u, v);
+                                double dpy = fac * Ex(i, i_, t) * Ey(j, j_, u) * Ez(k, k_, v) * rints_sum(t, u + 1, v);
+                                double dpz = fac * Ex(i, i_, t) * Ey(j, j_, u) * Ez(k, k_, v) * rints_sum(t, u, v + 1);
+
+                                double drx = fac * E1x(i, i_, t) * Ey(j, j_, u) * Ez(k, k_, v) * rints_sum(t, u, v);
+                                double dry = fac * Ex(i, i_, t) * E1y(j, j_, u) * Ez(k, k_, v) * rints_sum(t, u, v);
+                                double drz = fac * Ex(i, i_, t) * Ey(j, j_, u) * E1z(k, k_, v) * rints_sum(t, u, v);
+
+                                // d/dA
+                                ints_cart[0](mu, nu) += -1 * ((a / p) * dpx + drx); // -1 = charge of electron
+                                ints_cart[1](mu, nu) += -1 * ((a / p) * dpy + dry);
+                                ints_cart[2](mu, nu) += -1 * ((a / p) * dpz + drz);
+
+                                // d/dB
+                                ints_cart[3](mu, nu) += -1 * ((b / p) * dpx - drx);
+                                ints_cart[4](mu, nu) += -1 * ((b / p) * dpy - dry);
+                                ints_cart[5](mu, nu) += -1 * ((b / p) * dpz - drz);
+                            }
+        }
+
+    array<vec2d, 6> ints_sph;
+    for (int ideriv = 0; ideriv < 6; ideriv++)
+        ints_sph[ideriv] = trafo2Spherical(la, lb, ints_cart[ideriv]);
+
+    int ofs_norm_a = sp_data.offsets_norms[2 * ipair + 0];
+    int ofs_norm_b = sp_data.offsets_norms[2 * ipair + 1];
+    for (int ideriv = 0; ideriv < 6; ideriv++)
+        for (size_t mu = 0; mu < ints_sph[ideriv].dim<0>(); mu++)
+            for (size_t nu = 0; nu < ints_sph[ideriv].dim<1>(); nu++)
+            {
+                double norm_a = sp_data.norms[ofs_norm_a + mu];
+                double norm_b = sp_data.norms[ofs_norm_b + nu];
+                ints_sph[ideriv](mu, nu) *= norm_a * norm_b;
+            }
+
+    return ints_sph;
+}
+
+array<lible::vec2d, 6>
 LI::externalChargesD1Kernel(const int ipair, const vector<array<double, 4>> &charges,
                             const BoysGrid &boys_grid, const ShellPairData &sp_data)
 {
@@ -919,6 +1050,116 @@ LI::externalChargesD1Kernel(const int ipair, const vector<array<double, 4>> &cha
                 double norm_a = sp_data.norms[ofs_norm_a + mu];
                 double norm_b = sp_data.norms[ofs_norm_b + nu];
                 ints_sph[ideriv](mu, nu) *= norm_a * norm_b;
+            }
+
+    return ints_sph;
+}
+
+vector<array<lible::vec2d, 3>>
+LI::externalChargesOperatorErfD1Kernel(const int ipair, const vector<array<double, 4>> &charges,
+                                       const std::vector<double> &omegas, const BoysGrid &boys_grid, 
+				       const ShellPairData &sp_data)
+{
+    const int la = sp_data.la;
+    const int lb = sp_data.lb;
+    const int lab = la + lb;
+    const int cdepth_a = sp_data.cdepths[2 * ipair + 0];
+    const int cdepth_b = sp_data.cdepths[2 * ipair + 1];
+    const int cofs_a = sp_data.coffsets[2 * ipair + 0];
+    const int cofs_b = sp_data.coffsets[2 * ipair + 1];
+
+    const double *cexps_a = &sp_data.exps[cofs_a];
+    const double *cexps_b = &sp_data.exps[cofs_b];
+    const double *ccoeffs_a = &sp_data.coeffs[cofs_a];
+    const double *ccoeffs_b = &sp_data.coeffs[cofs_b];
+    const double *xyz_a = &sp_data.coords[6 * ipair + 0];
+    const double *xyz_b = &sp_data.coords[6 * ipair + 3];
+
+    const auto &cart_exps_a = cart_exps[la];
+    const auto &cart_exps_b = cart_exps[lb];
+
+    const int n_cart_a = numCartesians(la);
+    const int n_cart_b = numCartesians(lb);
+
+    int n_charges = charges.size();
+    vector<array<vec2d, 3>> ints_cart(n_charges);
+    for (int icharge = 0; icharge < n_charges; icharge++)
+        for (int icoord = 0; icoord < 3; icoord++)
+            ints_cart[icharge][icoord] = vec2d(Fill(0), n_cart_a, n_cart_b);
+
+    for (int ia = 0, iab = 0; ia < cdepth_a; ia++)
+        for (int ib = 0; ib < cdepth_b; ib++, iab++)
+        {
+            double a = cexps_a[ia];
+            double b = cexps_b[ib];
+            double da = ccoeffs_a[ia];
+            double db = ccoeffs_b[ib];
+
+            double p = a + b;
+            double dadb = da * db;
+            double fac = 2 * (M_PI / p) * dadb;
+
+            auto [Ex, Ey, Ez] = ecoeffsPrimitivePair(a, b, la, lb, xyz_a, xyz_b);
+
+            auto [E1x, E1y, E1z] = ecoeffsPrimitivePair_n1(a, b, la, lb, xyz_a, xyz_b,
+                                                           {Ex, Ey, Ez});
+
+            array<double, 3> xyz_p{(a * xyz_a[0] + b * xyz_b[0]) / p,
+                                   (a * xyz_a[1] + b * xyz_b[1]) / p,
+                                   (a * xyz_a[2] + b * xyz_b[2]) / p};
+
+            for (int icharge = 0; icharge < n_charges; icharge++)
+            {
+                auto [xc, yc, zc, charge] = charges[icharge];
+
+                array<double, 3> xyz_pc{xyz_p[0] - xc, xyz_p[1] - yc, xyz_p[2] - zc};
+
+                double xx{xyz_pc[0]}, xy{xyz_pc[1]}, xz{xyz_pc[2]};
+                double xyz_pc_dot = xx * xx + xy * xy + xz * xz;
+                double x = p * xyz_pc_dot;
+
+		double omega = omegas[icharge];
+		double erf_argument = omega * omega / (omega * omega + p);
+		double erf_factor = std::sqrt(erf_argument);
+                vector<double> fnx = calcBoysF(lab + 1, erf_argument * x, boys_grid);
+
+                vec3d rints = calcRInts3DErf(lab + 1, p, omega, &xyz_pc[0], &fnx[0]);
+
+                for (const auto &[i, j, k, mu] : cart_exps_a)
+                    for (const auto &[i_, j_, k_, nu] : cart_exps_b)
+                        for (int t = 0; t <= i + i_; t++)
+                            for (int u = 0; u <= j + j_; u++)
+                                for (int v = 0; v <= k + k_; v++)
+                                {
+                                    double Exyz = Ex(i, i_, t) * Ey(j, j_, u) * Ez(k, k_, v);
+
+                                    ints_cart[icharge][0](mu, nu) += erf_factor * charge * fac * Exyz * rints(t + 1, u, v);
+                                    ints_cart[icharge][1](mu, nu) += erf_factor * charge * fac * Exyz * rints(t, u + 1, v);
+                                    ints_cart[icharge][2](mu, nu) += erf_factor * charge * fac * Exyz * rints(t, u, v + 1);
+                                }
+            }
+        }
+
+    vector<array<vec2d, 3>> ints_sph(n_charges);
+    for (int icharge = 0; icharge < n_charges; icharge++)
+    {
+        ints_sph[icharge][0] = trafo2Spherical(la, lb, ints_cart[icharge][0]);
+        ints_sph[icharge][1] = trafo2Spherical(la, lb, ints_cart[icharge][1]);
+        ints_sph[icharge][2] = trafo2Spherical(la, lb, ints_cart[icharge][2]);
+    }
+
+    int ofs_norm_a = sp_data.offsets_norms[2 * ipair + 0];
+    int ofs_norm_b = sp_data.offsets_norms[2 * ipair + 1];
+    for (int icharge = 0; icharge < n_charges; icharge++)
+        for (size_t mu = 0; mu < ints_sph[icharge][0].dim<0>(); mu++)
+            for (size_t nu = 0; nu < ints_sph[icharge][0].dim<1>(); nu++)
+            {
+                double norm_a = sp_data.norms[ofs_norm_a + mu];
+                double norm_b = sp_data.norms[ofs_norm_b + nu];
+
+                ints_sph[icharge][0](mu, nu) *= norm_a * norm_b;
+                ints_sph[icharge][1](mu, nu) *= norm_a * norm_b;
+                ints_sph[icharge][2](mu, nu) *= norm_a * norm_b;
             }
 
     return ints_sph;

--- a/src/lible/ints/oneelints.cpp
+++ b/src/lible/ints/oneelints.cpp
@@ -72,7 +72,7 @@ namespace lible::ints
     vector<array<vec2d, 3>>
     externalChargesOperatorErfD1Kernel(const int ipair, const vector<array<double, 4>> &charges,
                                        const std::vector<double> &omegas, const BoysGrid &boys_grid, 
-				       const ShellPairData &sp_data);
+				                               const ShellPairData &sp_data);
 
     std::vector<vec2d>
     potentialAtExternalChargesKernel(const int ipair, const vector<array<double, 4>> &charges,

--- a/src/lible/ints/oneelints.cpp
+++ b/src/lible/ints/oneelints.cpp
@@ -782,11 +782,11 @@ lible::vec2d LI::externalChargesErfKernel(const int ipair,
                 double omega_squared = omegas[icharge] * omegas[icharge];
 
                 // second part of (52) in https://doi.org/10.1039/B605188J
-                double x = p * xyz_pc_dot * omega_squared / (omega_squared + p);
+                double x = p * omega_squared / (omega_squared + p);
 
-                vector<double> fnx = calcBoysF(lab, x, boys_grid);
+                vector<double> fnx = calcBoysF(lab, x * xyz_pc_dot, boys_grid);
 
-                vec3d rints = calcRInts3DErf(lab, p, omegas[icharge], &xyz_pc[0], &fnx[0]);
+                vec3d rints = calcRInts3D(lab, x , &xyz_pc[0], &fnx[0]);
 
                 for (int t = 0; t <= lab; t++)
                     for (int u = 0; u <= lab; u++)
@@ -888,7 +888,7 @@ LI::externalChargesErfD1Kernel(const int ipair, const vector<array<double, 4>> &
 
                 vector<double> fnx = calcBoysF(lab + 1, erf_argument * x, boys_grid);
 
-                vec3d rints = calcRInts3DErf(lab + 1, p, omega , &xyz_pc[0], &fnx[0]);
+                vec3d rints = calcRInts3D(lab + 1, p * erf_argument, &xyz_pc[0], &fnx[0]);
 
                 for (int t = 0; t <= lab + 1; t++)
                     for (int u = 0; u <= lab + 1; u++)
@@ -1123,7 +1123,7 @@ LI::externalChargesOperatorErfD1Kernel(const int ipair, const vector<array<doubl
 		double erf_factor = std::sqrt(erf_argument);
                 vector<double> fnx = calcBoysF(lab + 1, erf_argument * x, boys_grid);
 
-                vec3d rints = calcRInts3DErf(lab + 1, p, omega, &xyz_pc[0], &fnx[0]);
+                vec3d rints = calcRInts3D(lab + 1, p * erf_argument, &xyz_pc[0], &fnx[0]);
 
                 for (const auto &[i, j, k, mu] : cart_exps_a)
                     for (const auto &[i_, j_, k_, nu] : cart_exps_b)
@@ -1445,11 +1445,11 @@ LI::potentialAtExternalChargesErfKernel(const int ipair,
                 double omega_squared = omegas[icharge] * omegas[icharge];
 
                 // second part of (52) in https://doi.org/10.1039/B605188J
-                double x = p * xyz_pc_dot * omega_squared / (omega_squared + p);
+                double x = p  * omega_squared / (omega_squared + p);
 
-                vector<double> fnx = calcBoysF(lab, x, boys_grid);
+                vector<double> fnx = calcBoysF(lab, x * xyz_pc_dot, boys_grid);
 
-                vec3d rints = calcRInts3DErf(lab, p, omegas[icharge], &xyz_pc[0], &fnx[0]);
+                vec3d rints = calcRInts3D(lab, x, &xyz_pc[0], &fnx[0]);
 
                 for (int t = 0; t <= lab; t++)
                     for (int u = 0; u <= lab; u++)

--- a/src/lible/ints/rints.cpp
+++ b/src/lible/ints/rints.cpp
@@ -4,61 +4,6 @@ namespace LI = lible::ints;
 
 using std::array, std::vector;
 
-lible::vec3d LI::calcRInts3DErf(const int l, const double p, const double omega,
-                                const double *xyz_ab, const double *fnx)
-{
-    vec4d rints_buff(Fill(0), l + 1);
-
-    rints_buff(0, 0, 0, 0) = fnx[0];
-
-    double x = -2 * p * omega * omega / (p + omega * omega);
-    double y = x;
-    for (int n = 1; n <= l; n++)
-    {
-        rints_buff(n, 0, 0, 0) = fnx[n] * y;
-        y *= x;
-    }
-
-    // This clever loop is taken from HUMMR:
-    for (int n = l - 1; n >= 0; n--)
-    {
-        int n_ = l - n;
-        for (int t = 0; t <= n_; t++)
-            for (int u = 0; u <= n_ - t; u++)
-                for (int v = 0; v <= n_ - t - u; v++)
-                {
-                    if (t > 0)
-                    {
-                        rints_buff(n, t, u, v) = xyz_ab[0] * rints_buff(n + 1, t - 1, u, v);
-                        if (t > 1)
-                            rints_buff(n, t, u, v) += (t - 1) * rints_buff(n + 1, t - 2, u, v);
-                    }
-                    else
-                    {
-                        if (u > 0)
-                        {
-                            rints_buff(n, t, u, v) = xyz_ab[1] * rints_buff(n + 1, t, u - 1, v);
-                            if (u > 1)
-                                rints_buff(n, t, u, v) += (u - 1) * rints_buff(n + 1, t, u - 2, v);
-                        }
-                        else if (v > 0)
-                        {
-                            rints_buff(n, t, u, v) = xyz_ab[2] * rints_buff(n + 1, t, u, v - 1);
-                            if (v > 1)
-                                rints_buff(n, t, u, v) += (v - 1) * rints_buff(n + 1, t, u, v - 2);
-                        }
-                    }
-                }
-    }
-
-    vec3d rints(Fill(0), l + 1);
-    for (int t = 0; t <= l; t++)
-        for (int u = 0; u <= l - t; u++)
-            for (int v = 0; v <= l - t - u; v++)
-                rints(t, u, v) = rints_buff(0, t, u, v);
-
-    return rints;
-}
 lible::vec3d LI::calcRInts3D(const int l, const double p, const double *xyz_ab, const double *fnx)
 {
     vec4d rints_buff(Fill(0), l + 1);

--- a/src/lible/ints/rints.hpp
+++ b/src/lible/ints/rints.hpp
@@ -22,8 +22,6 @@ namespace lible
         /** Calculates the Hermite Coulomb integrals as a 3D array R(t, u, v). */
         vec3d calcRInts3D(const int l, const double p, const double *xyz_ab, const double *fnx);
 
-        vec3d calcRInts3DErf(const int l, const double p, const double omega, const double *xyz_ab, const double *fnx);
-
         std::vector<double> calcRInts_ERI2D1(const int l, const double alpha, const double fac,
                                              const double *fnx, const double *xyz_ab,
                                              const std::vector<std::array<int, 3>> &hermite_idxs_a,


### PR DESCRIPTION
I have added 
- the derivative D1 Kernel for erf-attenuated integrals (the overlap part)
- ... (operator part)
- removed excess RInts3DErf function 
I tested the derivative on the following system:
C2 (4e, 4o), def2-tzvp, distance 1.1 A
difference to numerical gradient -9E-7 
(for comparison in the point-charge case it is -3E-7) -> same order of magnitude I take as proof it is correct
[test_case.tar.gz](https://github.com/user-attachments/files/22638275/test_case.tar.gz)
